### PR TITLE
Proof of Concept: Add Pkg Params Using JSON Formatted String

### DIFF
--- a/EXAMPLES/PYTAN_API/create_package.py
+++ b/EXAMPLES/PYTAN_API/create_package.py
@@ -64,14 +64,46 @@ delete_kwargs = {}
 delete_kwargs["objtype"] = u'package'
 delete_kwargs["name"] = u'package49'
 
+json_formatted_parameter_list = [ '{'
+                                ,   '"parameters": ['
+                                ,     '{'
+                                ,       '"parameterType": "com.tanium.components.parameters::TextInputParameter",'
+                                ,       '"model": "com.tanium.components.parameters::TextInputParameter",'
+                                ,       '"key": "$1",'
+                                ,       '"validationExpressions": ['
+                                ,         '{'
+                                ,           '"expression": "",'
+                                ,           '"helpString": "",'
+                                ,           '"model": "com.tanium.models::ValidationExpression",'
+                                ,           '"parameterType": "com.tanium.models::ValidationExpression"'
+                                ,         '}'
+                                ,       '],'
+                                ,       '"label": "TextInput",'
+                                ,       '"helpString": "This is a parameter added with a JSON string."'
+                                ,     '},'
+                                ,     '{'
+                                ,       '"parameterType": "com.tanium.components.parameters::CheckBoxParameter",'
+                                ,       '"model": "com.tanium.components.parameters::CheckBoxParameter",'
+                                ,       '"key": "$2",'
+                                ,       '"label": "Checkbox",'
+                                ,       '"helpString": "This is a parameter added with a JSON string.",'
+                                ,       '"defaultValue": 0'
+                                ,     '}'
+                                ,   '],'
+                                ,   '"model": "com.tanium.components.parameters::ParametersArray",'
+                                ,   '"parameterType": "com.tanium.components.parameters::ParametersArray"'
+                                , '}'
+                                ]
+json_formatted_parameter_string = ''.join( json_formatted_parameter_list )
+
 # setup the arguments for the handler() class
 kwargs = {}
 kwargs["expire_seconds"] = 1500
 kwargs["display_name"] = u'package49 API test'
 kwargs["name"] = u'package49'
-kwargs["parameters_json_file"] = u'../doc/example_of_all_package_parameters.json'
+kwargs["parameters_json"] = json_formatted_parameter_string
 kwargs["verify_expire_seconds"] = 3600
-kwargs["command"] = u'package49 $1 $2 $3 $4 $5 $6 $7 $8'
+kwargs["command"] = u'package49 $1 $2'
 kwargs["file_urls"] = [u'3600::testing.vbs||https://content.tanium.com/files/initialcontent/bundles/2014-10-01_11-32-15-7844/custom_tagging_-_remove_tags_[non-windows]/CustomTagRemove.sh']
 kwargs["verify_filter_options"] = [u'and']
 kwargs["verify_filters"] = [u'Custom Tags, that contains:tag']
@@ -110,10 +142,10 @@ print out
 
 # delete the object, we are done with it now
 print "...CALLING: handler.delete() with args: {}".format(delete_kwargs)
-delete_response = handler.delete(**delete_kwargs)
+# delete_response = handler.delete(**delete_kwargs)
 
-print "...OUTPUT: print the delete response"
-print delete_response
+# print "...OUTPUT: print the delete response"
+# print delete_response
 
 '''STDOUT from running this:
 ...CALLING: pytan.handler() with args: {'username': 'Administrator', 'record_all_requests': True, 'loglevel': 1, 'debugformat': False, 'host': '10.0.1.240', 'password': 'Tanium2015!', 'port': '443'}
@@ -127,20 +159,20 @@ PackageSpec, name: 'package49', id: 95
 ...CALLING: handler.export_obj() with args {'export_format': 'json', 'obj': <taniumpy.object_types.package_spec.PackageSpec object at 0x102be8f90>}
 ...OUTPUT: print the objects returned in JSON format:
 {
-  "_type": "package_spec", 
-  "available_time": "1900-01-01T00:00:00", 
-  "command": "package49 $1 $2 $3 $4 $5 $6 $7 $8", 
-  "command_timeout": 9999, 
-  "creation_time": "2015-09-14T19:57:31", 
-  "deleted_flag": 0, 
-  "display_name": "package49 API test", 
-  "expire_seconds": 1500, 
+  "_type": "package_spec",
+  "available_time": "1900-01-01T00:00:00",
+  "command": "package49 $1 $2 $3 $4 $5 $6 $7 $8",
+  "command_timeout": 9999,
+  "creation_time": "2015-09-14T19:57:31",
+  "deleted_flag": 0,
+  "display_name": "package49 API test",
+  "expire_seconds": 1500,
   "files": {
-    "_type": "package_files", 
+    "_type": "package_files",
     "file": [
       {
-        "_type": "file", 
-        "bytes_downloaded": 0, 
+        "_type": "file",
+        "bytes_downloaded": 0,
 ..trimmed for brevity..
 ...CALLING: handler.delete() with args: {'objtype': u'package', 'name': u'package49'}
 ...OUTPUT: print the delete response


### PR DESCRIPTION
  - Alternative to using a JSON file for adding parameters
  - To avoid conflicts and confusion with parameter keys, only one source (file or string) is accepted for package parameters